### PR TITLE
Add ExampleProvider and context usage

### DIFF
--- a/rc/context/ExampleProvider.jsx
+++ b/rc/context/ExampleProvider.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ExampleContext from './ExampleContext';
+import useExample from '../hooks/useExample';
+
+function ExampleProvider({ children }) {
+  const { count, setCount } = useExample();
+
+  return (
+    <ExampleContext.Provider value={{ count, setCount }}>
+      {children}
+    </ExampleContext.Provider>
+  );
+}
+
+export default ExampleProvider;

--- a/rc/main.jsx
+++ b/rc/main.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import ExampleProvider from './context/ExampleProvider';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ExampleProvider>
+      <App />
+    </ExampleProvider>
   </React.StrictMode>,
 );

--- a/rc/pages/HomePage.jsx
+++ b/rc/pages/HomePage.jsx
@@ -1,7 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import ExampleContext from '../context/ExampleContext';
+import Button from '../components/Button';
 
 function HomePage() {
-  return <div>Home Page</div>;
+  const { count, setCount } = useContext(ExampleContext);
+
+  return (
+    <div>
+      <p>{count}</p>
+      <Button onClick={() => setCount((c) => c + 1)}>Increment</Button>
+    </div>
+  );
 }
 
 export default HomePage;


### PR DESCRIPTION
## Summary
- add `ExampleProvider` built on `useExample`
- wrap `App` with provider
- show `count` and increment button on `HomePage`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6a465438832d9c9ed5e9a8043b4a