### PR TITLE
Add theme switching with styled-components

### DIFF
--- a/rc/App.jsx
+++ b/rc/App.jsx
@@ -1,20 +1,31 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useState } from 'react';
+import styled, { ThemeProvider } from 'styled-components';
+import { lightTheme, darkTheme } from './theme';
+import ThemeToggle from './components/ThemeToggle';
 
 const Container = styled.div`
   display: flex;
+  flex-direction: column;
   min-height: 100vh;
   align-items: center;
   justify-content: center;
-  background-color: #121212;
-  color: #fff;
+  background-color: ${({ theme }) => theme.background};
+  color: ${({ theme }) => theme.text};
 `;
 
 function App() {
+  const [theme, setTheme] = useState('dark');
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
   return (
-    <Container>
-      <h1>Crypto Dashboard Starter</h1>
-    </Container>
+    <ThemeProvider theme={theme === 'dark' ? darkTheme : lightTheme}>
+      <Container>
+        <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
+        <h1>Crypto Dashboard Starter</h1>
+      </Container>
+    </ThemeProvider>
   );
 }
 

--- a/rc/components/ThemeToggle.jsx
+++ b/rc/components/ThemeToggle.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Button from './Button';
+
+function ThemeToggle({ theme, toggleTheme }) {
+  return (
+    <Button onClick={toggleTheme}>
+      Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
+    </Button>
+  );
+}
+
+export default ThemeToggle;

--- a/rc/theme.js
+++ b/rc/theme.js
@@ -1,0 +1,9 @@
+export const lightTheme = {
+  background: '#ffffff',
+  text: '#000000',
+};
+
+export const darkTheme = {
+  background: '#121212',
+  text: '#ffffff',
+};


### PR DESCRIPTION
## Summary
- define light and dark themes
- wrap application in ThemeProvider and manage theme state
- add a toggle component to switch themes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6a48ec60832da7707b992e52fafd