### PR TITLE
Add basic Vitest tests for utilities and components

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -14,6 +15,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }

--- a/rc/components/Button.test.jsx
+++ b/rc/components/Button.test.jsx
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Button from './Button';
+
+describe('Button', () => {
+  it('renders and handles onClick', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<Button onClick={handleClick}>Click me</Button>);
+    const button = getByRole('button', { name: /click me/i });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/rc/utils/format.test.js
+++ b/rc/utils/format.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { formatNumber } from './format';
+
+describe('formatNumber', () => {
+  it('formats numbers with commas', () => {
+    expect(formatNumber(12345)).toBe('12,345');
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- add Vitest, Testing Library, and jest-dom to dev setup
- configure jsdom test environment
- test number formatting helper and Button component

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6a4b53e4832dbaafe604ea75b437