### PR TITLE
Add crypto data hook and homepage listing

### DIFF
--- a/rc/hooks/useCryptoData.js
+++ b/rc/hooks/useCryptoData.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+import { fetchCoins } from '../utils/api';
+
+export default function useCryptoData() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchCoins()
+      .then(setData)
+      .catch((err) => setError(err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { data, loading, error };
+}

--- a/rc/pages/HomePage.jsx
+++ b/rc/pages/HomePage.jsx
@@ -1,7 +1,23 @@
 import React from 'react';
+import useCryptoData from '../hooks/useCryptoData';
 
 function HomePage() {
-  return <div>Home Page</div>;
-}
+  const { data: coins, loading, error } = useCryptoData();
 
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Failed to load data</div>;
+
+  return (
+    <div>
+      <h1>Crypto Prices</h1>
+      <ul>
+        {coins.map((coin) => (
+          <li key={coin.id}>
+            {coin.name}: ${coin.current_price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 export default HomePage;

--- a/rc/utils/api.js
+++ b/rc/utils/api.js
@@ -1,0 +1,8 @@
+export async function fetchCoins() {
+  const url = 'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd';
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Failed to fetch coins');
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add CoinGecko fetch utility
- create useCryptoData hook with loading/error handling
- show coin prices on HomePage

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6a50d594832db3ab1657417a6ccf