### PR TITLE
Add basic routing and navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
     "styled-components": "^6.1.0"
   },
   "devDependencies": {

--- a/rc/App.jsx
+++ b/rc/App.jsx
@@ -1,20 +1,29 @@
 import React from 'react';
 import styled from 'styled-components';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import HomePage from './pages/HomePage';
+import Dashboard from './pages/Dashboard';
+import NavBar from './components/NavBar';
 
 const Container = styled.div`
   display: flex;
+  flex-direction: column;
   min-height: 100vh;
-  align-items: center;
-  justify-content: center;
   background-color: #121212;
   color: #fff;
 `;
 
 function App() {
   return (
-    <Container>
-      <h1>Crypto Dashboard Starter</h1>
-    </Container>
+    <BrowserRouter>
+      <Container>
+        <NavBar />
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+        </Routes>
+      </Container>
+    </BrowserRouter>
   );
 }
 

--- a/rc/components/NavBar.jsx
+++ b/rc/components/NavBar.jsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Nav = styled.nav`
+  background: #333;
+  padding: 1rem;
+`;
+
+const StyledLink = styled(Link)`
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+`;
+
+function NavBar() {
+  return (
+    <Nav>
+      <StyledLink to="/">Home</StyledLink>
+      <StyledLink to="/dashboard">Dashboard</StyledLink>
+    </Nav>
+  );
+}
+
+export default NavBar;

--- a/rc/pages/Dashboard.jsx
+++ b/rc/pages/Dashboard.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Dashboard() {
+  return <div>Dashboard Page</div>;
+}
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency for client-side routing
- implement `BrowserRouter` with Home and Dashboard routes
- create `NavBar` component for navigation and placeholder `Dashboard` page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom" due to installation restrictions)*
- `npm install react-router-dom` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_689f6a4172ec832d8c063b180ee09042