### PR TITLE
Add trade history table with sorting and pagination

### DIFF
--- a/rc/components/TradeHistoryTable.jsx
+++ b/rc/components/TradeHistoryTable.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useMemo } from 'react';
+import styled from 'styled-components';
+import Button from './Button';
+
+const TableContainer = styled.div`
+  max-height: 300px;
+  overflow-y: auto;
+`;
+
+const StyledTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+`;
+
+const Th = styled.th`
+  cursor: pointer;
+  padding: 0.5rem;
+  text-align: left;
+  background: #f0f0f0;
+  position: sticky;
+  top: 0;
+`;
+
+const Td = styled.td`
+  padding: 0.5rem;
+  border-top: 1px solid #ddd;
+`;
+
+function TradeHistoryTable({ trades = [] }) {
+  const [sortConfig, setSortConfig] = useState({ key: 'date', direction: 'desc' });
+  const [currentPage, setCurrentPage] = useState(0);
+  const pageSize = 10;
+
+  const sortedTrades = useMemo(() => {
+    const sortable = [...trades];
+    sortable.sort((a, b) => {
+      const aVal = a[sortConfig.key];
+      const bVal = b[sortConfig.key];
+      if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1;
+      if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return sortable;
+  }, [trades, sortConfig]);
+
+  const pageCount = Math.ceil(sortedTrades.length / pageSize);
+  const paginatedTrades = sortedTrades.slice(
+    currentPage * pageSize,
+    currentPage * pageSize + pageSize
+  );
+
+  const requestSort = key => {
+    let direction = 'asc';
+    if (sortConfig.key === key && sortConfig.direction === 'asc') {
+      direction = 'desc';
+    }
+    setSortConfig({ key, direction });
+  };
+
+  const nextPage = () => setCurrentPage(p => Math.min(p + 1, pageCount - 1));
+  const prevPage = () => setCurrentPage(p => Math.max(p - 1, 0));
+
+  return (
+    <div>
+      <TableContainer>
+        <StyledTable>
+          <thead>
+            <tr>
+              <Th onClick={() => requestSort('pair')}>Pair</Th>
+              <Th onClick={() => requestSort('price')}>Price</Th>
+              <Th onClick={() => requestSort('amount')}>Amount</Th>
+              <Th onClick={() => requestSort('action')}>Action</Th>
+              <Th onClick={() => requestSort('date')}>Date</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {paginatedTrades.map((trade, idx) => (
+              <tr key={idx}>
+                <Td>{trade.pair}</Td>
+                <Td>{trade.price}</Td>
+                <Td>{trade.amount}</Td>
+                <Td>{trade.action}</Td>
+                <Td>{new Date(trade.date).toLocaleString()}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </StyledTable>
+      </TableContainer>
+      {pageCount > 1 && (
+        <div style={{ marginTop: '0.5rem' }}>
+          <Button onClick={prevPage} disabled={currentPage === 0} style={{ marginRight: '0.5rem' }}>
+            Previous
+          </Button>
+          <span>
+            {currentPage + 1} / {pageCount}
+          </span>
+          <Button
+            onClick={nextPage}
+            disabled={currentPage >= pageCount - 1}
+            style={{ marginLeft: '0.5rem' }}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TradeHistoryTable;
+

--- a/rc/pages/Dashboard.jsx
+++ b/rc/pages/Dashboard.jsx
@@ -1,7 +1,20 @@
 import React from 'react';
+import TradeHistoryTable from '../components/TradeHistoryTable';
+
+const sampleTrades = [
+  { pair: 'BTC/USD', price: 50000, amount: 0.1, action: 'buy', date: '2024-05-01T10:00:00Z' },
+  { pair: 'ETH/USD', price: 4000, amount: 1.5, action: 'sell', date: '2024-05-01T11:00:00Z' },
+  { pair: 'LTC/USD', price: 300, amount: 10, action: 'buy', date: '2024-05-02T09:30:00Z' },
+];
 
 function Dashboard() {
-  return <div>Dashboard Page</div>;
+  return (
+    <div>
+      <h2>Recent Trades</h2>
+      <TradeHistoryTable trades={sampleTrades} />
+    </div>
+  );
 }
 
 export default Dashboard;
+


### PR DESCRIPTION
## Summary
- add sortable and paginated TradeHistoryTable component
- show recent sample trades on dashboard

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_689f6e4479f4832da1acff82bca50696