### PR TITLE
feat: add asset breakdown card

### DIFF
--- a/rc/components/AssetBreakdownCard.jsx
+++ b/rc/components/AssetBreakdownCard.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Card = styled.div`
+  background: #1e1e1e;
+  padding: 1rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const List = styled.ul`
+  list-style: none;
+  width: 100%;
+`;
+
+const ListItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0;
+`;
+
+const Chart = styled.div`
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+`;
+
+function AssetBreakdownCard({ assets = [], view = 'chart' }) {
+  const gradient = React.useMemo(() => {
+    let cumulative = 0;
+    return assets
+      .map((asset) => {
+        const start = cumulative;
+        cumulative += asset.percentage * 3.6;
+        const end = cumulative;
+        return `${asset.color} ${start}deg ${end}deg`;
+      })
+      .join(', ');
+  }, [assets]);
+
+  return (
+    <Card>
+      <h3>Asset Breakdown</h3>
+      {view === 'list' ? (
+        <List>
+          {assets.map((asset) => (
+            <ListItem key={asset.symbol}>
+              <span style={{ color: asset.color }}>{asset.symbol}</span>
+              <span>{asset.percentage}%</span>
+            </ListItem>
+          ))}
+        </List>
+      ) : (
+        <Chart style={{ background: `conic-gradient(${gradient})` }} />
+      )}
+    </Card>
+  );
+}
+
+export default AssetBreakdownCard;
+

--- a/rc/pages/Dashboard.jsx
+++ b/rc/pages/Dashboard.jsx
@@ -1,7 +1,33 @@
 import React from 'react';
+import styled from 'styled-components';
+import AssetBreakdownCard from '../components/AssetBreakdownCard';
+
+const Grid = styled.div`
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+`;
+
+const SummaryCard = styled.div`
+  background: #1e1e1e;
+  padding: 1rem;
+  border-radius: 8px;
+`;
 
 function Dashboard() {
-  return <div>Dashboard Page</div>;
+  const assets = [
+    { symbol: 'BTC', percentage: 40, color: '#f7931a' },
+    { symbol: 'ETH', percentage: 30, color: '#3c3c3d' },
+    { symbol: 'ADA', percentage: 30, color: '#0F8AD9' },
+  ];
+
+  return (
+    <Grid>
+      <SummaryCard>Total Balance: $10,000</SummaryCard>
+      <SummaryCard>24h Change: +5%</SummaryCard>
+      <AssetBreakdownCard assets={assets} />
+    </Grid>
+  );
 }
 
 export default Dashboard;


### PR DESCRIPTION
## Summary
- add AssetBreakdownCard component that renders a pie chart or list of assets
- show asset breakdown card with sample data on the dashboard next to summary cards

## Testing
- `npm test --silent` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_689f6e435ad0832d9439a4a7b191fb8c