### PR TITLE
feat: add TopBar component

### DIFF
--- a/rc/components/TopBar.jsx
+++ b/rc/components/TopBar.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import styled from 'styled-components';
+import ThemeToggle from './ThemeToggle';
+
+const Bar = styled.header`
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+  z-index: 1000;
+`;
+
+const StatContainer = styled.div`
+  display: flex;
+`;
+
+const StatBadge = styled.div`
+  background: #f0f0f0;
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+`;
+
+const Actions = styled.div`
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+`;
+
+const UserArea = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 1rem;
+`;
+
+const Avatar = styled.img`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+`;
+
+function TopBar({ stats = [], user, theme, toggleTheme }) {
+  return (
+    <Bar>
+      <StatContainer>
+        {stats.map((stat) => (
+          <StatBadge key={stat.label}>
+            <strong>{stat.label}:</strong> {stat.value}
+          </StatBadge>
+        ))}
+      </StatContainer>
+      <Actions>
+        {theme && toggleTheme && (
+          <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
+        )}
+        {user && (
+          <UserArea>
+            {user.avatar && <Avatar src={user.avatar} alt="user avatar" />}
+            {user.name && <span>{user.name}</span>}
+          </UserArea>
+        )}
+      </Actions>
+    </Bar>
+  );
+}
+
+export default TopBar;
+

--- a/rc/components/TopBar.test.jsx
+++ b/rc/components/TopBar.test.jsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TopBar from './TopBar';
+
+const stats = [
+  { label: 'Total Value', value: '$10,000' },
+  { label: 'P/L', value: '+5%' }
+];
+
+const user = { name: 'Jane Doe', avatar: 'avatar.png' };
+
+describe('TopBar', () => {
+  it('renders stats and user info', () => {
+    const { getByText, getByAltText } = render(<TopBar stats={stats} user={user} />);
+    expect(getByText('Total Value')).toBeInTheDocument();
+    expect(getByText('$10,000')).toBeInTheDocument();
+    expect(getByText('P/L')).toBeInTheDocument();
+    expect(getByText('+5%')).toBeInTheDocument();
+    expect(getByText('Jane Doe')).toBeInTheDocument();
+    const avatar = getByAltText('user avatar');
+    expect(avatar).toHaveAttribute('src', 'avatar.png');
+  });
+
+  it('renders ThemeToggle when provided', () => {
+    const toggleTheme = vi.fn();
+    const { getByRole } = render(<TopBar theme="light" toggleTheme={toggleTheme} />);
+    const button = getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add sticky `TopBar` component with optional stats, user info, and theme toggle
- test rendering of stat badges, user avatar and ThemeToggle

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom'; npm install jsdom -> 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e3c29bc832d99ff39b1f97e7241