### PR TITLE
Add loading and empty state components and integrate into dashboard

### DIFF
--- a/rc/components/EmptyState.jsx
+++ b/rc/components/EmptyState.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from './Button';
+
+const Wrapper = styled.div`
+  text-align: center;
+  padding: 2rem;
+`;
+
+const ActionButton = styled(Button)`
+  margin-top: 1rem;
+`;
+
+function EmptyState({ message, action, actionLabel = 'Retry' }) {
+  return (
+    <Wrapper>
+      <p>{message}</p>
+      {action && (
+        <ActionButton onClick={action}>{actionLabel}</ActionButton>
+      )}
+    </Wrapper>
+  );
+}
+
+export default EmptyState;

--- a/rc/components/EmptyState.test.jsx
+++ b/rc/components/EmptyState.test.jsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EmptyState from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders message and optional action', () => {
+    const handleAction = vi.fn();
+    const { getByText } = render(
+      <EmptyState message="Nothing here" action={handleAction} actionLabel="Do something" />
+    );
+    expect(getByText('Nothing here')).toBeInTheDocument();
+    const button = getByText('Do something');
+    fireEvent.click(button);
+    expect(handleAction).toHaveBeenCalled();
+  });
+});

--- a/rc/components/LoadingIndicator.jsx
+++ b/rc/components/LoadingIndicator.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+`;
+
+const Spinner = styled.div`
+  width: 3rem;
+  height: 3rem;
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: ${spin} 1s linear infinite;
+`;
+
+function LoadingIndicator() {
+  return (
+    <Wrapper role="status" aria-label="Loading">
+      <Spinner />
+    </Wrapper>
+  );
+}
+
+export default LoadingIndicator;

--- a/rc/components/LoadingIndicator.test.jsx
+++ b/rc/components/LoadingIndicator.test.jsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LoadingIndicator from './LoadingIndicator';
+
+describe('LoadingIndicator', () => {
+  it('renders spinner with status role', () => {
+    const { getByRole } = render(<LoadingIndicator />);
+    const indicator = getByRole('status');
+    expect(indicator).toBeInTheDocument();
+  });
+});

--- a/rc/pages/Dashboard.jsx
+++ b/rc/pages/Dashboard.jsx
@@ -1,7 +1,41 @@
 import React from 'react';
+import useCryptoData from '../hooks/useCryptoData';
+import LoadingIndicator from '../components/LoadingIndicator';
+import EmptyState from '../components/EmptyState';
 
 function Dashboard() {
-  return <div>Dashboard Page</div>;
+  const { data, loading, error } = useCryptoData();
+
+  if (loading) {
+    return <LoadingIndicator />;
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        message="Failed to load data"
+        action={() => window.location.reload()}
+        actionLabel="Retry"
+      />
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return <EmptyState message="No data available" />;
+  }
+
+  return (
+    <div>
+      <h2>Crypto Markets</h2>
+      <ul>
+        {data.map((coin) => (
+          <li key={coin.id}>
+            {coin.name} - ${coin.current_price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 export default Dashboard;

--- a/rc/pages/HomePage.jsx
+++ b/rc/pages/HomePage.jsx
@@ -1,11 +1,28 @@
 import React from 'react';
 import useCryptoData from '../hooks/useCryptoData';
+import LoadingIndicator from '../components/LoadingIndicator';
+import EmptyState from '../components/EmptyState';
 
 function HomePage() {
   const { data: coins, loading, error } = useCryptoData();
 
-  if (loading) return <div>Loading...</div>;
-  if (error) return <div>Failed to load data</div>;
+  if (loading) {
+    return <LoadingIndicator />;
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        message="Failed to load data"
+        action={() => window.location.reload()}
+        actionLabel="Retry"
+      />
+    );
+  }
+
+  if (!coins || coins.length === 0) {
+    return <EmptyState message="No data available" />;
+  }
 
   return (
     <div>
@@ -20,4 +37,5 @@ function HomePage() {
     </div>
   );
 }
+
 export default HomePage;


### PR DESCRIPTION
## Summary
- add reusable `LoadingIndicator` spinner component
- create `EmptyState` component with optional action button
- use new components in `Dashboard` and `HomePage` to handle loading, error and empty data scenarios
- cover `EmptyState` and `LoadingIndicator` with basic tests

## Testing
- ⚠️ `npm install --save-dev jsdom` (403 403 Forbidden - GET https://registry.npmjs.org/cssstyle)
- ⚠️ `npm test -- --run` (MISSING DEPENDENCY  Cannot find dependency 'jsdom')

------
https://chatgpt.com/codex/tasks/task_e_689f6e46a3c0832d83b45844bc69b012