### PR TITLE
Add interactive chart legend for portfolio chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vite": "^5.0.0",
     "vitest": "^1.0.0",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/jest-dom": "^6.0.0"
+    "@testing-library/jest-dom": "^6.0.0",
+    "jsdom": "^22.1.0"
   }
 }

--- a/rc/components/ChartLegend.jsx
+++ b/rc/components/ChartLegend.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const LegendContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+`;
+
+const LegendItem = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  opacity: ${(p) => (p.visible ? 1 : 0.5)};
+`;
+
+const ColorBadge = styled.span`
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: ${(p) => p.color};
+`;
+
+function ChartLegend({ items, onToggle }) {
+  return (
+    <LegendContainer>
+      {items.map((item) => (
+        <LegendItem
+          key={item.label}
+          visible={item.visible}
+          type="button"
+          onClick={() => onToggle(item.label)}
+          aria-label={`toggle ${item.label}`}
+          aria-pressed={item.visible}
+        >
+          <ColorBadge color={item.color} />
+          <span>{item.label}</span>
+        </LegendItem>
+      ))}
+    </LegendContainer>
+  );
+}
+
+export default ChartLegend;

--- a/rc/components/ChartLegend.test.jsx
+++ b/rc/components/ChartLegend.test.jsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChartLegend from './ChartLegend';
+
+const sampleItems = [
+  { label: 'Stocks', color: '#1e90ff', visible: true },
+  { label: 'Bonds', color: '#ff6347', visible: false },
+];
+
+describe('ChartLegend', () => {
+  it('calls onToggle with label when an item is clicked', () => {
+    const handleToggle = vi.fn();
+    const { getByLabelText } = render(
+      <ChartLegend items={sampleItems} onToggle={handleToggle} />
+    );
+    const button = getByLabelText('toggle Stocks');
+    fireEvent.click(button);
+    expect(handleToggle).toHaveBeenCalledWith('Stocks');
+  });
+});

--- a/rc/components/PortfolioChart.jsx
+++ b/rc/components/PortfolioChart.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import ChartLegend from './ChartLegend';
+
+function PortfolioChart() {
+  const [items, setItems] = useState([
+    { label: 'Stocks', color: '#1e90ff', visible: true },
+    { label: 'Bonds', color: '#ff6347', visible: true },
+    { label: 'Crypto', color: '#32cd32', visible: true },
+  ]);
+
+  const handleToggle = (label) => {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.label === label ? { ...item, visible: !item.visible } : item
+      )
+    );
+    // Chart visibility toggling would go here
+  };
+
+  return (
+    <div>
+      {/* Chart rendering placeholder */}
+      <div>Portfolio chart placeholder</div>
+      <ChartLegend items={items} onToggle={handleToggle} />
+    </div>
+  );
+}
+
+export default PortfolioChart;

--- a/rc/pages/Dashboard.jsx
+++ b/rc/pages/Dashboard.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import PortfolioChart from '../components/PortfolioChart';
 
 function Dashboard() {
-  return <div>Dashboard Page</div>;
+  return (
+    <div>
+      <h1>Dashboard Page</h1>
+      <PortfolioChart />
+    </div>
+  );
 }
 
 export default Dashboard;


### PR DESCRIPTION
## Summary
- improve ChartLegend accessibility with button type and aria state
- add jsdom dependency and unit test for legend toggling

## Testing
- `npm install --save-dev jsdom` *(fails: 403 Forbidden - cssstyle)*
- `npm test` *(fails: Cannot find dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_689f6e41f23c832d862e38666b9a0f3e