### PR TITLE
feat: add sidebar component

### DIFF
--- a/rc/components/Sidebar.jsx
+++ b/rc/components/Sidebar.jsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Container = styled.aside`
+  width: 200px;
+  background: #f8f9fa;
+  padding: 1rem;
+  border-right: 1px solid #ddd;
+  height: 100vh;
+`;
+
+const Item = styled(Link)`
+  display: block;
+  color: #333;
+  margin-bottom: 0.5rem;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+function Sidebar({ items = [] }) {
+  return (
+    <Container data-testid="sidebar">
+      {items.map((item) => (
+        <Item key={item.to || item.label} to={item.to}>
+          {item.label}
+        </Item>
+      ))}
+    </Container>
+  );
+}
+
+export default Sidebar;

--- a/rc/components/Sidebar.test.jsx
+++ b/rc/components/Sidebar.test.jsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import Sidebar from './Sidebar';
+
+describe('Sidebar', () => {
+  it('renders provided items', () => {
+    const items = [
+      { label: 'Home', to: '/' },
+      { label: 'Dashboard', to: '/dashboard' },
+    ];
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <Sidebar items={items} />
+      </MemoryRouter>
+    );
+
+    items.forEach((item) => {
+      expect(getByText(item.label)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable sidebar navigation component
- include basic unit test for sidebar items rendering

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: vitest: not found)
- `npm run lint` (fails: ESLint couldn't find config)

------
https://chatgpt.com/codex/tasks/task_e_689f733fb87c832db5b2ac51ad453ffb