### PR TITLE
refactor: replace styled button with css module

### DIFF
--- a/rc/components/Button.jsx
+++ b/rc/components/Button.jsx
@@ -1,12 +1,5 @@
-import styled from 'styled-components';
+import styles from './Button.module.scss';
 
-const Button = styled.button`
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: 4px;
-  background: #1e90ff;
-  color: #fff;
-  cursor: pointer;
-`;
+const Button = (props) => <button className={styles.button} {...props} />;
 
 export default Button;

--- a/rc/components/Button.module.scss
+++ b/rc/components/Button.module.scss
@@ -1,0 +1,8 @@
+.button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #1e90ff;
+  color: #fff;
+  cursor: pointer;
+}

--- a/rc/components/EmptyState.jsx
+++ b/rc/components/EmptyState.jsx
@@ -1,24 +1,16 @@
 import React from 'react';
-import styled from 'styled-components';
 import Button from './Button';
-
-const Wrapper = styled.div`
-  text-align: center;
-  padding: 2rem;
-`;
-
-const ActionButton = styled(Button)`
-  margin-top: 1rem;
-`;
 
 function EmptyState({ message, action, actionLabel = 'Retry' }) {
   return (
-    <Wrapper>
+    <div style={{ textAlign: 'center', padding: '2rem' }}>
       <p>{message}</p>
       {action && (
-        <ActionButton onClick={action}>{actionLabel}</ActionButton>
+        <Button onClick={action} style={{ marginTop: '1rem' }}>
+          {actionLabel}
+        </Button>
       )}
-    </Wrapper>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace styled Button with functional component using CSS module
- update EmptyState to inline styles to match Button changes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f7579794c832d9416bfa6bb0032d4