### PR TITLE
refactor: use CSS modules for loading indicator

### DIFF
--- a/rc/components/LoadingIndicator.jsx
+++ b/rc/components/LoadingIndicator.jsx
@@ -1,32 +1,11 @@
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
-
-const spin = keyframes`
-  to {
-    transform: rotate(360deg);
-  }
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  padding: 2rem;
-`;
-
-const Spinner = styled.div`
-  width: 3rem;
-  height: 3rem;
-  border: 4px solid rgba(255, 255, 255, 0.3);
-  border-top-color: var(--color-primary);
-  border-radius: 50%;
-  animation: ${spin} 1s linear infinite;
-`;
+import styles from './LoadingIndicator.module.scss';
 
 function LoadingIndicator() {
   return (
-    <Wrapper role="status" aria-label="Loading">
-      <Spinner />
-    </Wrapper>
+    <div className={styles.wrapper} role="status" aria-label="Loading">
+      <div className={styles.spinner} />
+    </div>
   );
 }
 

--- a/rc/components/LoadingIndicator.module.scss
+++ b/rc/components/LoadingIndicator.module.scss
@@ -1,0 +1,18 @@
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.spinner {
+  width: 3rem;
+  height: 3rem;
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}


### PR DESCRIPTION
## Summary
- refactor LoadingIndicator to drop styled-components in favor of CSS modules
- add SCSS module with spinner animation styles

## Testing
- `npm test` *(fails: vitest not found, dependencies could not be installed due to 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f765160b0832db73f2516210c0dcd