### PR TITLE
Fix Vitest environment for component tests

### DIFF
--- a/rc/components/Button.test.jsx
+++ b/rc/components/Button.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import Button from './Button';
 
 describe('Button', () => {

--- a/rc/components/ChartLegend.test.jsx
+++ b/rc/components/ChartLegend.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import ChartLegend from './ChartLegend';
 
 const sampleItems = [

--- a/rc/components/EmptyState.test.jsx
+++ b/rc/components/EmptyState.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import EmptyState from './EmptyState';
 
 describe('EmptyState', () => {

--- a/rc/components/LoadingIndicator.test.jsx
+++ b/rc/components/LoadingIndicator.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import LoadingIndicator from './LoadingIndicator';
 
 describe('LoadingIndicator', () => {

--- a/rc/components/Sidebar.test.jsx
+++ b/rc/components/Sidebar.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import Sidebar from './Sidebar';
 
 describe('Sidebar', () => {

--- a/rc/components/TopBar.test.jsx
+++ b/rc/components/TopBar.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import TopBar from './TopBar';
 
 const stats = [


### PR DESCRIPTION
## Summary
- use `@testing-library/jest-dom/vitest` in component tests so matchers extend Vitest's expect

## Testing
- `npm test -- --run` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f7a64a9b4832dbf1302115276ac3a