### PR TITLE
Refactor dashboard styles to SCSS module

### DIFF
--- a/rc/pages/Dashboard.jsx
+++ b/rc/pages/Dashboard.jsx
@@ -1,23 +1,11 @@
 import React from 'react';
-import styled from 'styled-components';
-  import PortfolioChart from '../components/PortfolioChart';
+import PortfolioChart from '../components/PortfolioChart';
 import AssetBreakdownCard from '../components/AssetBreakdownCard';
 import TradeHistoryTable from '../components/TradeHistoryTable';
 import useCryptoData from '../hooks/useCryptoData';
 import LoadingIndicator from '../components/LoadingIndicator';
 import EmptyState from '../components/EmptyState';
-
-const Grid = styled.div`
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-`;
-
-const SummaryCard = styled.div`
-  background: #1e1e1e;
-  padding: 1rem;
-  border-radius: 8px;
-`;
+import styles from './Dashboard.module.scss';
 
 function Dashboard() {
   const sampleTrades = [
@@ -54,12 +42,12 @@ function Dashboard() {
 
   return (
     <div>
-      <Grid>
-        <SummaryCard>Total Balance: $10,000</SummaryCard>
-        <SummaryCard>24h Change: +5%</SummaryCard>
+      <div className={styles.grid}>
+        <div className={styles.summaryCard}>Total Balance: $10,000</div>
+        <div className={styles.summaryCard}>24h Change: +5%</div>
         <AssetBreakdownCard assets={assets} />
-  <PortfolioChart />
-      </Grid>
+        <PortfolioChart />
+      </div>
 
       <h2>Crypto Markets</h2>
       <ul>

--- a/rc/pages/Dashboard.module.scss
+++ b/rc/pages/Dashboard.module.scss
@@ -1,0 +1,11 @@
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.summaryCard {
+  background: #1e1e1e;
+  padding: 1rem;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- migrate Dashboard layout from styled-components to SCSS module
- apply `grid` and `summaryCard` classes for layout and card styling

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689f76573e04832dbc9cbed63662c907