### PR TITLE
Replace TopBar styled-components with CSS modules

### DIFF
--- a/rc/components/TopBar.jsx
+++ b/rc/components/TopBar.jsx
@@ -1,71 +1,35 @@
 import React from 'react';
-import styled from 'styled-components';
 import ThemeToggle from './ThemeToggle';
-
-const Bar = styled.header`
-  position: sticky;
-  top: 0;
-  display: flex;
-  align-items: center;
-  padding: 0.5rem 1rem;
-  background: #fff;
-  border-bottom: 1px solid #ddd;
-  z-index: 1000;
-`;
-
-const StatContainer = styled.div`
-  display: flex;
-`;
-
-const StatBadge = styled.div`
-  background: #f0f0f0;
-  margin-right: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.875rem;
-`;
-
-const Actions = styled.div`
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-`;
-
-const UserArea = styled.div`
-  display: flex;
-  align-items: center;
-  margin-left: 1rem;
-`;
-
-const Avatar = styled.img`
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  margin-right: 0.5rem;
-`;
+import styles from './TopBar.module.scss';
 
 function TopBar({ stats = [], user, theme, toggleTheme }) {
   return (
-    <Bar>
-      <StatContainer>
+    <header className={styles.bar}>
+      <div className={styles.statContainer}>
         {stats.map((stat) => (
-          <StatBadge key={stat.label}>
+          <div className={styles.statBadge} key={stat.label}>
             <strong>{stat.label}:</strong> {stat.value}
-          </StatBadge>
+          </div>
         ))}
-      </StatContainer>
-      <Actions>
+      </div>
+      <div className={styles.actions}>
         {theme && toggleTheme && (
           <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
         )}
         {user && (
-          <UserArea>
-            {user.avatar && <Avatar src={user.avatar} alt="user avatar" />}
+          <div className={styles.userArea}>
+            {user.avatar && (
+              <img
+                className={styles.avatar}
+                src={user.avatar}
+                alt="user avatar"
+              />
+            )}
             {user.name && <span>{user.name}</span>}
-          </UserArea>
+          </div>
         )}
-      </Actions>
-    </Bar>
+      </div>
+    </header>
   );
 }
 

--- a/rc/components/TopBar.module.scss
+++ b/rc/components/TopBar.module.scss
@@ -1,0 +1,41 @@
+.bar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+  z-index: 1000;
+}
+
+.statContainer {
+  display: flex;
+}
+
+.statBadge {
+  background: #f0f0f0;
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+.userArea {
+  display: flex;
+  align-items: center;
+  margin-left: 1rem;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Replaced TopBar's styled-components with plain HTML elements styled via a new CSS module.
- Added `TopBar.module.scss` defining styles for bar layout, stats badges, actions, and user area.

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f7653c91c832d8f5f833aebf009ff