### PR TITLE
refactor empty state styles

### DIFF
--- a/rc/components/EmptyState.jsx
+++ b/rc/components/EmptyState.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import Button from './Button';
+import styles from './EmptyState.module.scss';
 
 function EmptyState({ message, action, actionLabel = 'Retry' }) {
   return (
-    <div style={{ textAlign: 'center', padding: '2rem' }}>
+    <div className={styles.wrapper}>
       <p>{message}</p>
       {action && (
-        <Button onClick={action} style={{ marginTop: '1rem' }}>
+        <Button onClick={action} className={styles.actionButton}>
           {actionLabel}
         </Button>
       )}

--- a/rc/components/EmptyState.module.scss
+++ b/rc/components/EmptyState.module.scss
@@ -1,0 +1,8 @@
+.wrapper {
+  text-align: center;
+  padding: 2rem;
+}
+
+.actionButton {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- refactor `EmptyState` to use CSS modules instead of inline styles
- add dedicated `EmptyState.module.scss` for wrapper and action button spacing

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689f7654505c832da949f7f4300799bf