### PR TITLE
feat: add sidebar navigation

### DIFF
--- a/rc/App.jsx
+++ b/rc/App.jsx
@@ -1,9 +1,13 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import HomePage from './pages/HomePage';
-import Dashboard from './pages/Dashboard';
-import NavBar from './components/NavBar';
 import React, { useState, useEffect } from 'react';
+import Dashboard from './pages/Dashboard';
+import News from './pages/News';
+import Market from './pages/Market';
+import Messages from './pages/Messages';
+import Portfolio from './pages/Portfolio';
+import Settings from './pages/Settings';
 import ThemeToggle from './components/ThemeToggle';
+import Sidebar from './components/Sidebar';
 import styles from './App.module.scss';
 
 function App() {
@@ -24,13 +28,19 @@ function App() {
   return (
     <BrowserRouter>
       <div className={styles.container}>
-        <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
-        <h1>Crypto Dashboard Starter</h1>
-        <NavBar />
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-        </Routes>
+        <Sidebar />
+        <div className={styles.content}>
+          <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/news" element={<News />} />
+            <Route path="/market" element={<Market />} />
+            <Route path="/messages" element={<Messages />} />
+            <Route path="/portfolio" element={<Portfolio />} />
+            <Route path="/settings" element={<Settings />} />
+          </Routes>
+        </div>
       </div>
     </BrowserRouter>
   );

--- a/rc/App.module.scss
+++ b/rc/App.module.scss
@@ -1,9 +1,11 @@
 .container {
   display: flex;
-  flex-direction: column;
   min-height: 100vh;
-  align-items: center;
-  justify-content: center;
   background-color: var(--color-bg);
   color: var(--color-text);
+}
+
+.content {
+  flex: 1;
+  padding: 1rem;
 }

--- a/rc/components/Sidebar.jsx
+++ b/rc/components/Sidebar.jsx
@@ -1,30 +1,53 @@
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Container = styled.aside`
-  width: 200px;
-  background: #f8f9fa;
-  padding: 1rem;
-  border-right: 1px solid #ddd;
+  width: 220px;
+  background: #0b0d21;
+  color: #fff;
   height: 100vh;
+  padding-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
 `;
 
-const Item = styled(Link)`
-  display: block;
-  color: #333;
-  margin-bottom: 0.5rem;
+const Title = styled.h1`
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0 1.5rem;
+  margin-bottom: 2rem;
+`;
+
+const Item = styled(NavLink)`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
   text-decoration: none;
 
-  &:hover {
-    text-decoration: underline;
+  &.active {
+    background: rgba(255, 255, 255, 0.1);
   }
 `;
 
-function Sidebar({ items = [] }) {
+const defaultItems = [
+  { label: 'Dashboard', to: '/dashboard', icon: '📊' },
+  { label: 'News', to: '/news', icon: '📰' },
+  { label: 'Market', to: '/market', icon: '💹' },
+  { label: 'Messages', to: '/messages', icon: '💬' },
+  { label: 'Portfolio', to: '/portfolio', icon: '💼' },
+  { label: 'Settings', to: '/settings', icon: '⚙️' },
+];
+
+function Sidebar({ items = defaultItems }) {
   return (
     <Container data-testid="sidebar">
+      <Title>SIGNALS</Title>
       {items.map((item) => (
-        <Item key={item.to || item.label} to={item.to}>
+        <Item key={item.to} to={item.to}>
+          {item.icon}
           {item.label}
         </Item>
       ))}

--- a/rc/components/Sidebar.test.jsx
+++ b/rc/components/Sidebar.test.jsx
@@ -5,20 +5,17 @@ import '@testing-library/jest-dom/vitest';
 import Sidebar from './Sidebar';
 
 describe('Sidebar', () => {
-  it('renders provided items', () => {
-    const items = [
-      { label: 'Home', to: '/' },
-      { label: 'Dashboard', to: '/dashboard' },
-    ];
-
+  it('renders default navigation items', () => {
     const { getByText } = render(
       <MemoryRouter>
-        <Sidebar items={items} />
+        <Sidebar />
       </MemoryRouter>
     );
 
-    items.forEach((item) => {
-      expect(getByText(item.label)).toBeInTheDocument();
-    });
+    ['Dashboard', 'News', 'Market', 'Messages', 'Portfolio', 'Settings'].forEach(
+      (label) => {
+        expect(getByText(label)).toBeInTheDocument();
+      }
+    );
   });
 });

--- a/rc/pages/Market.jsx
+++ b/rc/pages/Market.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Market() {
+  return <div>Market Page</div>;
+}
+
+export default Market;

--- a/rc/pages/Messages.jsx
+++ b/rc/pages/Messages.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Messages() {
+  return <div>Messages Page</div>;
+}
+
+export default Messages;

--- a/rc/pages/News.jsx
+++ b/rc/pages/News.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function News() {
+  return <div>News Page</div>;
+}
+
+export default News;

--- a/rc/pages/Portfolio.jsx
+++ b/rc/pages/Portfolio.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Portfolio() {
+  return <div>Portfolio Page</div>;
+}
+
+export default Portfolio;

--- a/rc/pages/Settings.jsx
+++ b/rc/pages/Settings.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Settings() {
+  return <div>Settings Page</div>;
+}
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add styled sidebar with navigation links
- wire sidebar into app layout and routes
- add placeholder pages for new sections

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f8833b424832da3be6996666546a7