### PR TITLE
style: update global color palette

### DIFF
--- a/rc/styles/global.css
+++ b/rc/styles/global.css
@@ -1,13 +1,14 @@
 :root {
-  --color-bg: #121212;
+  --color-bg: #0d0b33;
   --color-text: #ffffff;
-  --color-primary: #1e88e5;
+  --color-primary: #00d1b2;
   --font-family-base: 'Inter', sans-serif;
 }
 
 [data-theme='light'] {
-  --color-bg: #ffffff;
+  --color-bg: #f4f0ff;
   --color-text: #121212;
+  --color-primary: #5865f2;
 }
 
 * {

--- a/rc/theme.js
+++ b/rc/theme.js
@@ -1,9 +1,11 @@
 export const lightTheme = {
-  background: '#ffffff',
-  text: '#000000',
+  background: '#f4f0ff',
+  text: '#121212',
+  primary: '#5865f2',
 };
 
 export const darkTheme = {
-  background: '#121212',
+  background: '#0d0b33',
   text: '#ffffff',
+  primary: '#00d1b2',
 };


### PR DESCRIPTION
## Summary
- restyle global color variables for dark and light themes
- mirror palette in theme definitions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f88a2d914832db81dfcb4a8c23a41