### PR TITLE
feat: add rolling theme toggle

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
-import Button from './Button';
+import styles from './ThemeToggle.module.scss';
 
 function ThemeToggle({ theme, toggleTheme }) {
   return (
-    <Button onClick={toggleTheme}>
-      Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
-    </Button>
+    <button
+      type="button"
+      aria-label="Toggle theme"
+      onClick={toggleTheme}
+      className={`${styles.toggle} ${theme === 'light' ? styles.light : styles.dark}`}
+    >
+      <span className={styles.ball} />
+    </button>
   );
 }
 

--- a/src/components/ThemeToggle.module.scss
+++ b/src/components/ThemeToggle.module.scss
@@ -1,0 +1,51 @@
+.toggle {
+  position: relative;
+  width: 50px;
+  height: 26px;
+  border: none;
+  border-radius: 13px;
+  padding: 0;
+  background: #222;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.ball {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.4s ease, background 0.3s, box-shadow 0.3s;
+}
+
+.dark {
+  background: #222;
+}
+
+.dark .ball::before {
+  content: '';
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  background: #222;
+  border-radius: 50%;
+  top: 0;
+  left: 8px;
+}
+
+.light {
+  background: #fff;
+}
+
+.light .ball {
+  transform: translateX(24px);
+  background: #ffdf5d;
+  box-shadow: 0 0 8px rgba(255, 223, 93, 0.8);
+}
+
+.light .ball::before {
+  content: none;
+}


### PR DESCRIPTION
## Summary
- animate theme switch with rolling sun and moon
- add styles for dark and light track, ball transitions

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_689f8dec1084832db123ad6946f5a966