### PR TITLE
feat: add basic settings page

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,7 +1,81 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styles from './Settings.module.scss';
 
 function Settings() {
-  return <div>Settings Page</div>;
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [theme, setTheme] = useState('light');
+  const [notifications, setNotifications] = useState(true);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // TODO: Persist settings to backend
+    console.log('Saved settings', {
+      username,
+      email,
+      password,
+      theme,
+      notifications,
+    });
+    alert('Settings saved!');
+  };
+
+  return (
+    <div className={styles.container}>
+      <h2>Settings</h2>
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <label className={styles.field}>
+          <span>Username</span>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span>Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span>Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span>Theme</span>
+          <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+
+        <label className={styles.fieldCheckbox}>
+          <input
+            type="checkbox"
+            checked={notifications}
+            onChange={(e) => setNotifications(e.target.checked)}
+          />
+          <span>Enable Notifications</span>
+        </label>
+
+        <button className={styles.saveButton} type="submit">
+          Save Settings
+        </button>
+      </form>
+    </div>
+  );
 }
 
 export default Settings;
+

--- a/src/pages/Settings.module.scss
+++ b/src/pages/Settings.module.scss
@@ -1,0 +1,26 @@
+.container {
+  padding: 1rem;
+  max-width: 600px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.fieldCheckbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.saveButton {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- implement a simple settings form with profile, theme and notification options
- add basic styles for settings layout

## Testing
- `npm test` (fails: Unable to find an element with the text: Dashboard)
- `npm run lint` (fails: 78 errors)

------
https://chatgpt.com/codex/tasks/task_e_689f9ac5d184832d9b4f51feea6e97a7