### PR TITLE
feat: use global color variables in sidebar

### DIFF
--- a/src/components/Sidebar.module.scss
+++ b/src/components/Sidebar.module.scss
@@ -1,7 +1,7 @@
 .container {
   width: 220px;
-  background: #0b0d21;
-  color: #fff;
+  background: var(--color-surface);
+  color: var(--color-text);
   height: 100vh;
   padding-top: 1.5rem;
   display: flex;
@@ -20,11 +20,11 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: #fff;
+  color: var(--color-text);
   padding: 0.75rem 1.5rem;
   text-decoration: none;
 }
 
 .active {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--color-border);
 }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 const Container = styled.aside`
   width: 220px;
-  background: #0b0d21;
-  color: #fff;
+  background: var(--color-surface);
+  color: var(--color-text);
   height: 100vh;
   padding-top: 1.5rem;
   display: flex;
@@ -23,12 +23,12 @@ const Item = styled(NavLink)`
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: #fff;
+  color: var(--color-text);
   padding: 0.75rem 1.5rem;
   text-decoration: none;
 
   &.active {
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--color-border);
   }
 `;
 


### PR DESCRIPTION
## Summary
- replace hard-coded sidebar colors with theme variables
- ensure layout sidebar also uses global color tokens

## Testing
- `npm test`
- `npm run lint` *(fails: 'stats' is missing in props validation, 'user' is missing in props validation, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fa0ae2ca0832da538e097942b8e80