### PR TITLE
feat: redesign settings page

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -2,76 +2,133 @@ import React, { useState } from 'react';
 import styles from './Settings.module.scss';
 
 function Settings() {
-  const [username, setUsername] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [theme, setTheme] = useState('light');
-  const [notifications, setNotifications] = useState(true);
+  const [profile, setProfile] = useState({
+    username: '',
+    displayName: '',
+    email: '',
+    taxId: '',
+    address: '',
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setProfile((prev) => ({ ...prev, [name]: value }));
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
     // TODO: Persist settings to backend
-    console.log('Saved settings', {
-      username,
-      email,
-      password,
-      theme,
-      notifications,
-    });
+    console.log('Saved settings', profile);
     alert('Settings saved!');
   };
 
   return (
-    <div className={styles.container}>
-      <h2>Settings</h2>
-      <form className={styles.form} onSubmit={handleSubmit}>
-        <label className={styles.field}>
-          <span>Username</span>
+    <div className={styles.wrapper}>
+      <header className={styles.header}>
+        <div>
+          <h2>Settings</h2>
+          <p>Manage your details and personal preferences here.</p>
+        </div>
+        <div className={styles.headerButtons}>
+          <button type="button">Invite</button>
+          <button type="button" className={styles.upgradeButton}>
+            Upgrade
+          </button>
+        </div>
+      </header>
+
+      <nav className={styles.tabs}>
+        <button className={styles.activeTab}>Profile</button>
+        <button type="button">Security</button>
+        <button type="button">Billing</button>
+        <button type="button">Notifications</button>
+        <button type="button">Integrations</button>
+      </nav>
+
+      <div className={styles.notice}>
+        <span>Please confirm your email to protect your profile</span>
+        <button type="button">Verify email</button>
+      </div>
+
+      <form onSubmit={handleSubmit} className={styles.section}>
+        <h3>My profile</h3>
+
+        <div className={styles.fieldRow}>
+          <label htmlFor="username">Username</label>
           <input
+            id="username"
+            name="username"
             type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
+            value={profile.username}
+            onChange={handleChange}
           />
-        </label>
+        </div>
 
-        <label className={styles.field}>
-          <span>Email</span>
+        <div className={styles.fieldRow}>
+          <label>Photo</label>
+          <div className={styles.photoRow}>
+            <div className={styles.avatar} />
+            <button type="button">Upload</button>
+          </div>
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label htmlFor="displayName">Display name</label>
           <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            id="displayName"
+            name="displayName"
+            type="text"
+            value={profile.displayName}
+            onChange={handleChange}
           />
-        </label>
+        </div>
 
-        <label className={styles.field}>
-          <span>Password</span>
+        <div className={styles.fieldRow}>
+          <label htmlFor="email">Contact email</label>
+          <div className={styles.emailRow}>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              value={profile.email}
+              onChange={handleChange}
+            />
+            <button type="button">Verify</button>
+          </div>
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label htmlFor="taxId">Business tax ID</label>
           <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            id="taxId"
+            name="taxId"
+            type="text"
+            value={profile.taxId}
+            onChange={handleChange}
           />
-        </label>
+        </div>
 
-        <label className={styles.field}>
-          <span>Theme</span>
-          <select value={theme} onChange={(e) => setTheme(e.target.value)}>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </label>
-
-        <label className={styles.fieldCheckbox}>
+        <div className={styles.fieldRow}>
+          <label htmlFor="address">Business address</label>
           <input
-            type="checkbox"
-            checked={notifications}
-            onChange={(e) => setNotifications(e.target.checked)}
+            id="address"
+            name="address"
+            type="text"
+            value={profile.address}
+            onChange={handleChange}
           />
-          <span>Enable Notifications</span>
-        </label>
+        </div>
 
-        <button className={styles.saveButton} type="submit">
-          Save Settings
-        </button>
+        <div className={styles.fieldRow}>
+          <label>Xero integration</label>
+          <button type="button">Connect</button>
+        </div>
+
+        <div className={styles.actions}>
+          <button type="submit" className={styles.saveButton}>
+            Save Settings
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/src/pages/Settings.module.scss
+++ b/src/pages/Settings.module.scss
@@ -1,26 +1,144 @@
-.container {
-  padding: 1rem;
-  max-width: 600px;
+.wrapper {
+  padding: 2rem;
+  color: var(--color-text);
 }
 
-.form {
+.header {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.headerButtons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.upgradeButton {
+  background: var(--color-primary);
+  border: none;
+  color: #000;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.tabs {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.tabs button {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  opacity: 0.6;
+  padding: 0.5rem 0;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.activeTab {
+  opacity: 1;
+  border-color: var(--color-primary);
+}
+
+.notice {
+  background: var(--color-negative);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.notice button {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.section {
+  background: var(--color-surface);
+  border-radius: 8px;
+  padding: 1rem 1.5rem;
+}
+
+.section h3 {
+  margin-bottom: 1rem;
+}
+
+.fieldRow {
+  display: grid;
+  grid-template-columns: 200px 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.fieldRow:last-child {
+  border-bottom: none;
+}
+
+.fieldRow label {
+  font-weight: 600;
+}
+
+.fieldRow input {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  padding: 0.5rem;
+  border-radius: 4px;
+  color: var(--color-text);
+}
+
+.photoRow {
+  display: flex;
+  align-items: center;
   gap: 1rem;
 }
 
-.field {
-  display: flex;
-  flex-direction: column;
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--color-border);
 }
 
-.fieldCheckbox {
+.emailRow {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.saveButton {
-  align-self: flex-start;
-  padding: 0.5rem 1rem;
+.fieldRow button {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
 }
+
+.actions {
+  margin-top: 1rem;
+  text-align: right;
+}
+
+.saveButton {
+  background: var(--color-primary);
+  color: #000;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- overhaul settings page layout with header, tab navigation, and email notice
- add profile form for username, photo, contact info, business details, and integrations
- style settings interface for dark theme and responsive grid layout

## Testing
- `npm test` *(fails: Failed to resolve import "../common/ThemeToggle" in TopBar.jsx)*
- `npm run lint` *(fails: 85 errors, e.g., missing prop-types in TopBar.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689fa1ef8210832db82c826c4f7190af