### PR TITLE
feat: refresh color palette for accessibility

### DIFF
--- a/src/components/ThemeToggle.module.scss
+++ b/src/components/ThemeToggle.module.scss
@@ -5,7 +5,7 @@
   border: none;
   border-radius: 13px;
   padding: 0;
-  background: #222;
+  background: var(--color-surface);
   cursor: pointer;
   transition: background 0.3s;
 }
@@ -17,12 +17,12 @@
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: #fff;
+  background: var(--color-text);
   transition: transform 0.4s ease, background 0.3s, box-shadow 0.3s;
 }
 
 .dark {
-  background: #222;
+  background: var(--color-surface);
 }
 
 .dark .ball::before {
@@ -30,20 +30,20 @@
   position: absolute;
   width: 22px;
   height: 22px;
-  background: #222;
+  background: var(--color-surface);
   border-radius: 50%;
   top: 0;
   left: 8px;
 }
 
 .light {
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .light .ball {
   transform: translateX(24px);
-  background: #ffdf5d;
-  box-shadow: 0 0 8px rgba(255, 223, 93, 0.8);
+  background: var(--color-accent-4);
+  box-shadow: 0 0 8px rgba(255, 212, 59, 0.8);
 }
 
 .light .ball::before {

--- a/src/components/charts/AssetBreakdownCard.module.scss
+++ b/src/components/charts/AssetBreakdownCard.module.scss
@@ -1,5 +1,5 @@
 .card {
-  background: #1e1e1e;
+  background: var(--color-surface);
   padding: 1rem;
   border-radius: 8px;
   display: flex;

--- a/src/components/charts/ChartLegend.test.jsx
+++ b/src/components/charts/ChartLegend.test.jsx
@@ -4,8 +4,8 @@ import '@testing-library/jest-dom/vitest';
 import ChartLegend from './ChartLegend';
 
 const sampleItems = [
-  { label: 'Stocks', color: '#1e90ff', visible: true },
-  { label: 'Bonds', color: '#ff6347', visible: false },
+  { label: 'Stocks', color: 'var(--color-accent-1)', visible: true },
+  { label: 'Bonds', color: 'var(--color-accent-2)', visible: false },
 ];
 
 describe('ChartLegend', () => {

--- a/src/components/charts/MetricComparison.jsx
+++ b/src/components/charts/MetricComparison.jsx
@@ -4,9 +4,9 @@ import styles from './MetricComparison.module.scss';
 function MetricComparison({ label, current, previous, period }) {
   const difference = current - previous;
   const percent = previous !== 0 ? (difference / previous) * 100 : 0;
-  let color = '#666';
-  if (percent > 0) color = 'green';
-  else if (percent < 0) color = 'red';
+  let color = 'var(--color-text)';
+  if (percent > 0) color = 'var(--color-accent-3)';
+  else if (percent < 0) color = 'var(--color-negative)';
   const sign = percent > 0 ? '+' : '';
 
   return (

--- a/src/components/charts/PortfolioChart.jsx
+++ b/src/components/charts/PortfolioChart.jsx
@@ -3,9 +3,9 @@ import ChartLegend from './ChartLegend';
 
 function PortfolioChart() {
   const [items, setItems] = useState([
-    { label: 'Stocks', color: '#1e90ff', visible: true },
-    { label: 'Bonds', color: '#ff6347', visible: true },
-    { label: 'Crypto', color: '#32cd32', visible: true },
+    { label: 'Stocks', color: 'var(--color-accent-1)', visible: true },
+    { label: 'Bonds', color: 'var(--color-accent-2)', visible: true },
+    { label: 'Crypto', color: 'var(--color-accent-3)', visible: true },
   ]);
 
   const handleToggle = (label) => {

--- a/src/components/layout/NavBar.module.scss
+++ b/src/components/layout/NavBar.module.scss
@@ -1,10 +1,10 @@
 .nav {
-  background: #333;
+  background: var(--color-surface);
   padding: 1rem;
 }
 
 .link {
-  color: #fff;
+  color: var(--color-text);
   margin-right: 1rem;
   text-decoration: none;
 }

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ThemeToggle from '../common/ThemeToggle';
+import ThemeToggle from '../ThemeToggle';
 import styles from './TopBar.module.scss';
 
 function TopBar({ stats = [], user, theme, toggleTheme }) {

--- a/src/components/layout/TopBar.module.scss
+++ b/src/components/layout/TopBar.module.scss
@@ -4,8 +4,8 @@
   display: flex;
   align-items: center;
   padding: 0.5rem 1rem;
-  background: #fff;
-  border-bottom: 1px solid #ddd;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
   z-index: 1000;
 }
 
@@ -14,7 +14,7 @@
 }
 
 .statBadge {
-  background: #f0f0f0;
+  background: var(--color-surface);
   margin-right: 0.5rem;
   padding: 0.25rem 0.5rem;
   border-radius: 4px;

--- a/src/components/tables/TradeHistoryTable.module.scss
+++ b/src/components/tables/TradeHistoryTable.module.scss
@@ -12,14 +12,14 @@
   cursor: pointer;
   padding: 0.5rem;
   text-align: left;
-  background: #f0f0f0;
+  background: var(--color-surface);
   position: sticky;
   top: 0;
 }
 
 .td {
   padding: 0.5rem;
-  border-top: 1px solid #ddd;
+  border-top: 1px solid var(--color-border);
 }
 
 .pagination {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,33 +1,33 @@
 :root {
-  --color-bg: #0d0b33;
-  --color-text: #ffffff;
-  --color-primary: #00d1b2;
-  --color-surface: #1e1e1e;
-  --color-border: #333333;
-  --color-negative: #ff3860;
-  --color-accent-1: #1e90ff;
-  --color-accent-2: #ff6347;
-  --color-accent-3: #32cd32;
-  --color-accent-4: #f7931a;
-  --color-accent-5: #3c3c3d;
-  --color-accent-6: #0F8AD9;
+  --color-bg: #1a1d32;
+  --color-text: #e6e6f0;
+  --color-primary: #8b5cf6;
+  --color-surface: #2a2d4a;
+  --color-border: #3f425e;
+  --color-negative: #e63946;
+  --color-accent-1: #4dabf7;
+  --color-accent-2: #ffa94d;
+  --color-accent-3: #51cf66;
+  --color-accent-4: #ffd43b;
+  --color-accent-5: #868e96;
+  --color-accent-6: #0ea5e9;
 
   --font-family-base: 'Inter', sans-serif;
 }
 
 [data-theme='light'] {
-  --color-bg: #f4f0ff;
-  --color-text: #121212;
-  --color-primary: #5865f2;
-  --color-surface: #ffffff;
-  --color-border: #dddddd;
-  --color-negative: #ff3860;
-  --color-accent-1: #1e90ff;
-  --color-accent-2: #ff6347;
-  --color-accent-3: #32cd32;
-  --color-accent-4: #f7931a;
-  --color-accent-5: #3c3c3d;
-  --color-accent-6: #0F8AD9;
+  --color-bg: #f5f3ff;
+  --color-text: #1e1e2e;
+  --color-primary: #705cf6;
+  --color-surface: #f8f7ff;
+  --color-border: #d0d0da;
+  --color-negative: #e63946;
+  --color-accent-1: #4dabf7;
+  --color-accent-2: #ffa94d;
+  --color-accent-3: #51cf66;
+  --color-accent-4: #ffd43b;
+  --color-accent-5: #868e96;
+  --color-accent-6: #0ea5e9;
 
 }
 


### PR DESCRIPTION
## Summary
- expand theme with cohesive, accessible palette avoiding pure black/white
- refactor components to consume shared CSS variables for colors
- adjust tests to align with updated color tokens

## Testing
- `npm test`
- `npm run lint` *(fails: 'stats' is missing in props validation etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fa2a39f20832d90b8a668a5409b65