### PR TITLE
Add navigation and theme toggle to top bar

### DIFF
--- a/src/components/layout/NavBar.module.scss
+++ b/src/components/layout/NavBar.module.scss
@@ -1,6 +1,6 @@
 .nav {
-  background: var(--color-surface);
-  padding: 1rem;
+  display: flex;
+  margin-right: 1rem;
 }
 
 .link {

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import ThemeToggle from '../ThemeToggle';
+import NavBar from './NavBar';
 import styles from './TopBar.module.scss';
 
 function TopBar({ stats = [], user, theme, toggleTheme }) {
   return (
     <header className={styles.bar}>
+      <NavBar />
       <div className={styles.statContainer}>
         {stats.map((stat) => (
           <div className={styles.statBadge} key={stat.label}>
@@ -13,9 +15,9 @@ function TopBar({ stats = [], user, theme, toggleTheme }) {
         ))}
       </div>
       <div className={styles.actions}>
-        {/* {theme && toggleTheme && (
+        {theme && toggleTheme && (
           <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
-        )} */}
+        )}
         {user && (
           <div className={styles.userArea}>
             {user.avatar && (

--- a/src/components/layout/TopBar.test.jsx
+++ b/src/components/layout/TopBar.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/vitest';
 import TopBar from './TopBar';
 
@@ -11,8 +12,14 @@ const stats = [
 const user = { name: 'Jane Doe', avatar: 'avatar.png' };
 
 describe('TopBar', () => {
-  it('renders stats and user info', () => {
-    const { getByText, getByAltText } = render(<TopBar stats={stats} user={user} />);
+  it('renders stats, navigation links, and user info', () => {
+    const { getByText, getByAltText } = render(
+      <MemoryRouter>
+        <TopBar stats={stats} user={user} />
+      </MemoryRouter>
+    );
+    expect(getByText('Home')).toBeInTheDocument();
+    expect(getByText('Dashboard')).toBeInTheDocument();
     expect(getByText('Total Value', { exact: false })).toBeInTheDocument();
     expect(getByText('$10,000')).toBeInTheDocument();
     expect(getByText('P/L', { exact: false })).toBeInTheDocument();
@@ -24,8 +31,12 @@ describe('TopBar', () => {
 
   it('renders ThemeToggle when provided', () => {
     const toggleTheme = vi.fn();
-    const { getByRole } = render(<TopBar theme="light" toggleTheme={toggleTheme} />);
-    const button = getByRole('button');
+    const { getByRole } = render(
+      <MemoryRouter>
+        <TopBar theme="light" toggleTheme={toggleTheme} />
+      </MemoryRouter>
+    );
+    const button = getByRole('button', { name: /toggle theme/i });
     expect(button).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- integrate navigation links and theme toggle into top bar
- streamline top bar navigation styles
- test top bar rendering of nav links and theme toggle

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 'React must be in scope', missing prop-types, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689faf8befa0832dacbcb83be74716a3