### PR TITLE
Compute dashboard portfolio totals from market data

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import {
   TradeHistoryTable,
 } from '../components';
 import useCryptoData from '../hooks/useCryptoData';
+import { formatNumber } from '../utils/format';
 import styles from './Dashboard.module.scss';
 
 function Dashboard() {
@@ -24,6 +25,24 @@ function Dashboard() {
   ];
 
   const { data, loading, error } = useCryptoData();
+
+  const holdings = {
+    btc: 0.5,
+    eth: 2,
+    ada: 1000,
+  };
+
+  const totalBalance = data.reduce((sum, coin) => {
+    const amount = holdings[coin.symbol];
+    if (!amount) return sum;
+    return sum + amount * coin.current_price;
+  }, 0);
+
+  const totalChange = data.reduce((sum, coin) => {
+    const amount = holdings[coin.symbol];
+    if (!amount) return sum;
+    return sum + amount * coin.price_change_24h;
+  }, 0);
 
   if (loading) {
     return <LoadingIndicator />;
@@ -46,8 +65,12 @@ function Dashboard() {
   return (
     <div>
       <div className={styles.grid}>
-        <div className={styles.summaryCard}>Total Balance: $10,000</div>
-        <div className={styles.summaryCard}>24h Change: +5%</div>
+        <div className={styles.summaryCard}>
+          Total Balance: ${formatNumber(totalBalance)}
+        </div>
+        <div className={styles.summaryCard}>
+          24h Change: {totalChange >= 0 ? '+' : '-'}${formatNumber(Math.abs(totalChange))}
+        </div>
         <AssetBreakdownCard assets={assets} />
         <PortfolioChart />
       </div>

--- a/src/pages/__tests__/Dashboard.test.jsx
+++ b/src/pages/__tests__/Dashboard.test.jsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { render, screen } from '@testing-library/react';
+import Dashboard from '../Dashboard';
+
+expect.extend(matchers);
+
+const sampleData = [
+  { id: 'bitcoin', symbol: 'btc', name: 'Bitcoin', current_price: 50000, price_change_24h: 1000 },
+  { id: 'ethereum', symbol: 'eth', name: 'Ethereum', current_price: 4000, price_change_24h: -100 },
+  { id: 'cardano', symbol: 'ada', name: 'Cardano', current_price: 2, price_change_24h: 0.1 },
+];
+
+vi.mock('../../hooks/useCryptoData', () => ({
+  default: () => ({ data: sampleData, loading: false, error: null }),
+}));
+
+describe('Dashboard', () => {
+  it('shows calculated total balance and 24h change', () => {
+    render(<Dashboard />);
+
+    expect(screen.getByText('Total Balance: $35,000')).toBeInTheDocument();
+    expect(screen.getByText('24h Change: +$400')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- derive dashboard total balance and 24h change from live crypto prices
- add tests ensuring calculated portfolio summary is rendered

## Testing
- `npm test`
- `npm run lint` *(fails: missing prop-types and React scope errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689fd03c36c8832d84e7adebbbdf7ba2