### PR TITLE
Add responsive SCSS mixins and layout adjustments

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -1,11 +1,21 @@
+@use "./styles/breakpoints" as *;
+
 .container {
   display: flex;
   min-height: 100vh;
   background-color: var(--color-bg);
   color: var(--color-text);
+
+  @include mobile {
+    flex-direction: column;
+  }
 }
 
 .content {
   flex: 1;
   padding: 1rem;
+
+  @include mobile {
+    padding: 0.5rem;
+  }
 }

--- a/src/components/Sidebar.module.scss
+++ b/src/components/Sidebar.module.scss
@@ -1,3 +1,5 @@
+@use "../styles/breakpoints" as *;
+
 .container {
   width: 220px;
   background: var(--color-surface);
@@ -7,6 +9,15 @@
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--color-border);
+
+  @include mobile {
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    padding-top: 0.5rem;
+    border-right: none;
+    border-bottom: 1px solid var(--color-border);
+  }
 }
 
 .title {
@@ -15,6 +26,10 @@
   letter-spacing: 0.1em;
   padding: 0 1.5rem;
   margin-bottom: 2rem;
+
+  @include mobile {
+    display: none;
+  }
 }
 
 .item {
@@ -25,6 +40,13 @@
   text-decoration: none;
   border-radius: 0 1rem 1rem 0;
   transition: background 0.3s, color 0.3s;
+
+  @include mobile {
+    flex: 1;
+    justify-content: center;
+    padding: 0.5rem;
+    border-radius: 0;
+  }
 }
 
 .item:hover {

--- a/src/components/layout/TopBar.module.scss
+++ b/src/components/layout/TopBar.module.scss
@@ -1,3 +1,5 @@
+@use "../../styles/breakpoints" as *;
+
 .bar {
   position: sticky;
   top: 0;
@@ -7,10 +9,19 @@
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
   z-index: 1000;
+
+  @include mobile {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .statContainer {
   display: flex;
+
+  @include mobile {
+    margin-bottom: 0.5rem;
+  }
 }
 
 .statBadge {
@@ -25,12 +36,22 @@
   margin-left: auto;
   display: flex;
   align-items: center;
+
+  @include mobile {
+    margin-left: 0;
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 .userArea {
   display: flex;
   align-items: center;
   margin-left: 1rem;
+
+  @include mobile {
+    margin-left: 0;
+  }
 }
 
 .avatar {

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -1,0 +1,7 @@
+$breakpoint-mobile: 600px;
+
+@mixin mobile {
+  @media (max-width: $breakpoint-mobile) {
+    @content;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable mobile breakpoint mixin
- adjust app layout to stack content on small screens
- tweak sidebar and top bar to behave better on mobile

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689fd419c524832d89f6ab716494b4e2