### PR TITLE
feat: add dashboard loading skeletons

### DIFF
--- a/src/components/common/LoadingIndicator.jsx
+++ b/src/components/common/LoadingIndicator.jsx
@@ -1,6 +1,20 @@
 import React from 'react';
 import styles from './LoadingIndicator.module.scss';
 
+function SummaryCardSkeleton({ className }) {
+  return <div className={className} />;
+}
+
+function TableSkeleton({ rows = 3, className }) {
+  return (
+    <div>
+      {Array.from({ length: rows }).map((_, index) => (
+        <div key={index} className={className} />
+      ))}
+    </div>
+  );
+}
+
 function LoadingIndicator() {
   return (
     <div className={styles.wrapper} role="status" aria-label="Loading">
@@ -10,3 +24,4 @@ function LoadingIndicator() {
 }
 
 export default LoadingIndicator;
+export { SummaryCardSkeleton, TableSkeleton };

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -1,3 +1,4 @@
 export { default as Button } from './Button';
 export { default as EmptyState } from './EmptyState';
-export { default as LoadingIndicator } from './LoadingIndicator';
+export { default as LoadingIndicator, SummaryCardSkeleton, TableSkeleton } from './LoadingIndicator';
+

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {
   AssetBreakdownCard,
   EmptyState,
-  LoadingIndicator,
   PortfolioChart,
   TradeHistoryTable,
+  SummaryCardSkeleton,
+  TableSkeleton,
 } from '../components';
 import useCryptoData from '../hooks/useCryptoData';
 import styles from './Dashboard.module.scss';
@@ -26,7 +27,20 @@ function Dashboard() {
   const { data, loading, error } = useCryptoData();
 
   if (loading) {
-    return <LoadingIndicator />;
+    return (
+      <div>
+        <div className={styles.grid}>
+          <SummaryCardSkeleton className={styles.skeletonCard} />
+          <SummaryCardSkeleton className={styles.skeletonCard} />
+          <SummaryCardSkeleton className={styles.skeletonCard} />
+          <SummaryCardSkeleton className={styles.skeletonCard} />
+        </div>
+        <h2>Crypto Markets</h2>
+        <TableSkeleton rows={3} className={styles.tableSkeletonRow} />
+        <h2>Recent Trades</h2>
+        <TableSkeleton rows={3} className={styles.tableSkeletonRow} />
+      </div>
+    );
   }
 
   if (error) {

--- a/src/pages/Dashboard.module.scss
+++ b/src/pages/Dashboard.module.scss
@@ -10,3 +10,30 @@
   padding: 1rem;
   border-radius: 8px;
 }
+
+@keyframes pulse {
+  0% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+
+.skeletonCard {
+  @extend .summaryCard;
+  animation: pulse 1.5s ease-in-out infinite;
+  color: transparent;
+}
+
+.tableSkeletonRow {
+  width: 100%;
+  height: 1.25rem;
+  border-radius: 4px;
+  background: var(--color-surface);
+  animation: pulse 1.5s ease-in-out infinite;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add reusable SummaryCardSkeleton and TableSkeleton components
- show skeleton placeholders in Dashboard while crypto data loads
- style skeleton cards and rows in Dashboard module

## Testing
- `npm run lint` (fails: react prop-types and React in scope warnings)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd040f81c832d827eb99c733d3342