### PR TITLE
feat: add mobile sidebar toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,8 +11,14 @@ import styles from './App.module.scss';
 
 function App() {
   const [theme, setTheme] = useState('dark');
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   const toggleTheme = () => {
     setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  const toggleSidebar = () => {
+    setSidebarOpen(prev => !prev);
   };
 
   useEffect(() => {
@@ -27,9 +33,13 @@ function App() {
   return (
     <BrowserRouter>
       <div className={styles.container}>
-        <Sidebar />
+        <Sidebar open={sidebarOpen} />
         <div className={styles.content}>
-          <TopBar theme={theme} toggleTheme={toggleTheme} />
+          <TopBar
+            theme={theme}
+            toggleTheme={toggleTheme}
+            toggleSidebar={toggleSidebar}
+          />
           <Routes>
             <Route path="/" element={<Dashboard />} />
             <Route path="/dashboard" element={<Dashboard />} />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import App from './App';
+
+describe('App', () => {
+  it('toggles sidebar when hamburger menu is clicked', () => {
+    const { getByLabelText, getByTestId } = render(<App />);
+    const button = getByLabelText(/toggle sidebar/i);
+    const sidebar = getByTestId('sidebar');
+    expect(sidebar).toHaveAttribute('data-open', 'false');
+    fireEvent.click(button);
+    expect(sidebar).toHaveAttribute('data-open', 'true');
+  });
+});

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -10,6 +10,14 @@ const Container = styled.aside`
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--color-border);
+
+  @media (max-width: 600px) {
+    position: fixed;
+    top: 0;
+    left: ${(props) => (props.open ? '0' : '-220px')};
+    transition: left 0.3s ease;
+    z-index: 1000;
+  }
 `;
 
 const Title = styled.h1`
@@ -49,9 +57,9 @@ const defaultItems = [
   { label: 'Settings', to: '/settings' },
 ];
 
-function Sidebar({ items = defaultItems }) {
+function Sidebar({ items = defaultItems, open }) {
   return (
-    <Container data-testid="sidebar">
+    <Container data-testid="sidebar" open={open} data-open={open}>
       <Title>SIGNALS</Title>
       {items.map((item) => (
         <Item key={item.to} to={item.to}>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -3,9 +3,18 @@ import ThemeToggle from '../ThemeToggle';
 import NavBar from './NavBar';
 import styles from './TopBar.module.scss';
 
-function TopBar({ stats = [], user, theme, toggleTheme }) {
+function TopBar({ stats = [], user, theme, toggleTheme, toggleSidebar }) {
   return (
     <header className={styles.bar}>
+      {toggleSidebar && (
+        <button
+          className={styles.menuButton}
+          aria-label="Toggle sidebar"
+          onClick={toggleSidebar}
+        >
+          &#9776;
+        </button>
+      )}
       <NavBar />
       <div className={styles.statContainer}>
         {stats.map((stat) => (

--- a/src/components/layout/TopBar.module.scss
+++ b/src/components/layout/TopBar.module.scss
@@ -60,3 +60,16 @@
   border-radius: 50%;
   margin-right: 0.5rem;
 }
+
+.menuButton {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  margin-right: 0.5rem;
+  cursor: pointer;
+
+  @include mobile {
+    display: block;
+  }
+}

--- a/src/components/layout/TopBar.test.jsx
+++ b/src/components/layout/TopBar.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/vitest';
 import TopBar from './TopBar';
@@ -38,6 +38,18 @@ describe('TopBar', () => {
     );
     const button = getByRole('button', { name: /toggle theme/i });
     expect(button).toBeInTheDocument();
+  });
+
+  it('calls toggleSidebar when hamburger is clicked', () => {
+    const toggleSidebar = vi.fn();
+    const { getByLabelText } = render(
+      <MemoryRouter>
+        <TopBar toggleSidebar={toggleSidebar} />
+      </MemoryRouter>
+    );
+    const button = getByLabelText(/toggle sidebar/i);
+    fireEvent.click(button);
+    expect(toggleSidebar).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- add state and hamburger menu to toggle sidebar on mobile
- style sidebar to slide in/out on small screens
- test sidebar toggle behavior

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_689fd5dd66c8832da0d2e6fadacddc42