### PR TITLE
feat: modernize base font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Crypto Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,7 +12,7 @@
   --color-accent-5: #868e96;
   --color-accent-6: #0ea5e9;
 
-  --font-family-base: 'Inter', sans-serif;
+  --font-family-base: 'Poppins', sans-serif;
 }
 
 [data-theme='light'] {


### PR DESCRIPTION
## Summary
- use Poppins as the base font
- load Poppins from Google Fonts

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_689fd0c1cce0832d9ea562122d6bc737