### PR TITLE
Fetch trades from API and test sorting

### DIFF
--- a/src/components/tables/TradeHistoryTable.test.jsx
+++ b/src/components/tables/TradeHistoryTable.test.jsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import TradeHistoryTable from './TradeHistoryTable';
+import { fetchTrades } from '../../utils/api';
+
+describe('TradeHistoryTable', () => {
+  it('sorts and paginates fetched trades', async () => {
+    const trades = await fetchTrades();
+    render(<TradeHistoryTable trades={trades} />);
+
+    // sort ascending by price
+    fireEvent.click(screen.getByText('Price'));
+    let firstRow = screen.getAllByRole('row')[1];
+    expect(firstRow.children[0].textContent).toBe('BTC/USD');
+
+    // sort descending by price
+    fireEvent.click(screen.getByText('Price'));
+    firstRow = screen.getAllByRole('row')[1];
+    expect(firstRow.children[0].textContent).toBe('COIN14/USD');
+
+    // go to next page after sorting ascending again
+    fireEvent.click(screen.getByText('Price'));
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    firstRow = screen.getAllByRole('row')[1];
+    expect(firstRow.children[0].textContent).toBe('COIN10/USD');
+  });
+});

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   AssetBreakdownCard,
   EmptyState,
@@ -9,14 +9,17 @@ import {
 } from '../components';
 import useCryptoData from '../hooks/useCryptoData';
 import { formatNumber } from '../utils/format';
+import { fetchTrades } from '../utils/api';
 import styles from './Dashboard.module.scss';
 
 function Dashboard() {
-  const sampleTrades = [
-    { pair: 'BTC/USD', price: 50000, amount: 0.1, action: 'buy', date: '2024-05-01T10:00:00Z' },
-    { pair: 'ETH/USD', price: 4000, amount: 1.5, action: 'sell', date: '2024-05-01T11:00:00Z' },
-    { pair: 'LTC/USD', price: 300, amount: 10, action: 'buy', date: '2024-05-02T09:30:00Z' },
-  ];
+  const [trades, setTrades] = useState([]);
+
+  useEffect(() => {
+    fetchTrades()
+      .then(setTrades)
+      .catch(() => setTrades([]));
+  }, []);
 
   const assets = [
     { symbol: 'BTC', percentage: 40, color: 'var(--color-accent-4)' },
@@ -99,10 +102,10 @@ function Dashboard() {
       </ul>
 
       <h2>Recent Trades</h2>
-      <TradeHistoryTable trades={sampleTrades} />
+      <TradeHistoryTable trades={trades} />
     </div>
   );
-  
+
 }
 
 

--- a/src/pages/tests/Dashboard.test.jsx
+++ b/src/pages/tests/Dashboard.test.jsx
@@ -22,7 +22,7 @@ describe('Dashboard', () => {
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
   });
 
-  it('displays summary cards, market list, and trade history on success', () => {
+  it('displays summary cards, market list, and trade history on success', async () => {
     const mockData = [
       { id: 'btc', name: 'Bitcoin', current_price: 50000 },
       { id: 'eth', name: 'Ethereum', current_price: 4000 },
@@ -33,8 +33,8 @@ describe('Dashboard', () => {
     expect(screen.getByText('Total Balance: $10,000')).toBeInTheDocument();
     expect(screen.getByText('24h Change: +5%')).toBeInTheDocument();
     expect(screen.getByText('Bitcoin - $50000')).toBeInTheDocument();
-    // TradeHistoryTable renders sample trade
-    expect(screen.getByText('BTC/USD')).toBeInTheDocument();
+    // TradeHistoryTable renders fetched trade
+    expect(await screen.findByText('BTC/USD')).toBeInTheDocument();
   });
 });
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -6,3 +6,24 @@ export async function fetchCoins() {
   }
   return response.json();
 }
+
+export async function fetchTrades() {
+  const baseDate = Date.UTC(2024, 4, 1, 10, 0, 0);
+  const trades = [
+    {
+      pair: 'BTC/USD',
+      price: 100,
+      amount: 0.1,
+      action: 'buy',
+      date: new Date(baseDate).toISOString(),
+    },
+    ...Array.from({ length: 14 }, (_, i) => ({
+      pair: `COIN${i + 1}/USD`,
+      price: 101 + i,
+      amount: i + 2,
+      action: (i + 1) % 2 === 0 ? 'sell' : 'buy',
+      date: new Date(baseDate + (i + 1) * 60000).toISOString(),
+    })),
+  ];
+  return Promise.resolve(trades);
+}


### PR DESCRIPTION
## Summary
- Load trade history in Dashboard from new `fetchTrades` utility instead of hard-coded sample data.
- Introduce `fetchTrades` with mock data and add tests validating sorting and pagination.
- Update Dashboard test to await asynchronously fetched trades.

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd03f2c54832daede4522e56b85a1