### PR TITLE
feat: add AI signals page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import Dashboard from './pages/Dashboard';
 import News from './pages/News';
 import Market from './pages/Market';
-import Messages from './pages/Messages';
+import AISignals from './pages/AISignals';
 import Portfolio from './pages/Portfolio';
 import Settings from './pages/Settings';
 import { Sidebar, TopBar } from './components';
@@ -45,7 +45,7 @@ function App() {
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/news" element={<News />} />
             <Route path="/market" element={<Market />} />
-            <Route path="/messages" element={<Messages />} />
+              <Route path="/signals" element={<AISignals />} />
             <Route path="/portfolio" element={<Portfolio />} />
             <Route path="/settings" element={<Settings />} />
           </Routes>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -21,7 +21,7 @@ const icons = {
       <path d="M5 9v10h2V9H5zm4 4v6h2v-6H9zm4-6v12h2V7h-2zm4 8v4h2v-4h-2z" />
     </svg>
   ),
-  messages: (
+    signals: (
     <svg viewBox="0 0 24 24" aria-hidden="true" className={styles.icon}>
       <path d="M21 6h-2v9H6v2h9l5 5V6zM17 2H3v14l4-4h10V2z" />
     </svg>
@@ -42,7 +42,7 @@ const defaultItems = [
   { label: 'Dashboard', to: '/dashboard', icon: icons.dashboard },
   { label: 'News', to: '/news', icon: icons.news },
   { label: 'Market', to: '/market', icon: icons.market },
-  { label: 'Messages', to: '/messages', icon: icons.messages },
+    { label: 'AI Signals', to: '/signals', icon: icons.signals },
   { label: 'Portfolio', to: '/portfolio', icon: icons.portfolio },
   { label: 'Settings', to: '/settings', icon: icons.settings },
 ];

--- a/src/components/Sidebar.test.jsx
+++ b/src/components/Sidebar.test.jsx
@@ -12,7 +12,7 @@ describe('Sidebar', () => {
       </MemoryRouter>
     );
 
-    ['Dashboard', 'News', 'Market', 'Messages', 'Portfolio', 'Settings'].forEach(
+      ['Dashboard', 'News', 'Market', 'AI Signals', 'Portfolio', 'Settings'].forEach(
       (label) => {
         expect(getByText(label, { exact: false })).toBeInTheDocument();
       }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -52,7 +52,7 @@ const defaultItems = [
   { label: 'Dashboard', to: '/dashboard' },
   { label: 'News', to: '/news' },
   { label: 'Market', to: '/market' },
-  { label: 'Messages', to: '/messages' },
+    { label: 'AI Signals', to: '/signals' },
   { label: 'Portfolio', to: '/portfolio' },
   { label: 'Settings', to: '/settings' },
 ];

--- a/src/components/layout/Sidebar.test.jsx
+++ b/src/components/layout/Sidebar.test.jsx
@@ -12,7 +12,7 @@ describe('Sidebar', () => {
       </MemoryRouter>
     );
 
-    ['Dashboard', 'News', 'Market', 'Messages', 'Portfolio', 'Settings'].forEach(
+      ['Dashboard', 'News', 'Market', 'AI Signals', 'Portfolio', 'Settings'].forEach(
       (label) => {
         expect(getByText(label, { exact: false })).toBeInTheDocument();
       }

--- a/src/pages/AISignals.jsx
+++ b/src/pages/AISignals.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import styles from './AISignals.module.scss';
+
+const priceData = {
+  BTC: [34300, 34250, 34120, 34050, 33900, 33800, 33750, 33680, 33600, 33500, 33400, 33300, 33250, 33120, 33000],
+  ETH: [2000, 2025, 2050, 2070, 2090, 2110, 2130, 2150, 2170, 2190, 2210, 2230, 2250, 2270, 2290],
+  ADA: [0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59, 0.6, 0.61, 0.62, 0.63, 0.64],
+};
+
+function calculateEMA(values, period) {
+  const k = 2 / (period + 1);
+  return values.reduce((prev, curr, idx) => {
+    if (idx === 0) return curr;
+    return curr * k + prev * (1 - k);
+  });
+}
+
+function calculateRSI(values, period) {
+  let gains = 0;
+  let losses = 0;
+  for (let i = values.length - period; i < values.length; i++) {
+    const diff = values[i] - values[i - 1];
+    if (diff >= 0) gains += diff;
+    else losses -= diff;
+  }
+  const avgGain = gains / period;
+  const avgLoss = losses / period;
+  if (avgLoss === 0) return 100;
+  const rs = avgGain / avgLoss;
+  return 100 - 100 / (1 + rs);
+}
+
+function createSignal(symbol, prices) {
+  const rsi = calculateRSI(prices, 14);
+  const ema = calculateEMA(prices, 10);
+  const action = rsi > 70 ? 'SELL' : 'BUY';
+  const confidence = Math.floor(Math.random() * 40) + 60;
+  return {
+    symbol,
+    rsi: rsi?.toFixed(2),
+    ema: ema?.toFixed(2),
+    action,
+    confidence,
+  };
+}
+
+function AISignals() {
+  const [signals, setSignals] = useState([]);
+
+  useEffect(() => {
+    const symbols = Object.keys(priceData);
+    let index = 0;
+    const interval = setInterval(() => {
+      if (index < symbols.length) {
+        const sym = symbols[index];
+        setSignals((prev) => [...prev, createSignal(sym, priceData[sym])]);
+        index += 1;
+      } else {
+        clearInterval(interval);
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      {signals.map((sig, i) => (
+        <div
+          key={i}
+          className={`${styles.signalCard} ${
+            sig.action === 'BUY' ? styles.buy : styles.sell
+          }`}
+        >
+          <h3>{sig.symbol}</h3>
+          <p>RSI: {sig.rsi}</p>
+          <p>EMA: {sig.ema}</p>
+          <p>Confidence: {sig.confidence}%</p>
+          <strong>{sig.action}</strong>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default AISignals;

--- a/src/pages/AISignals.module.scss
+++ b/src/pages/AISignals.module.scss
@@ -1,0 +1,35 @@
+ .container {
+   padding: 1.5rem;
+   display: flex;
+   flex-direction: column;
+   gap: 1rem;
+ }
+
+ .signalCard {
+   border-radius: 8px;
+   padding: 1rem 1.5rem;
+   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+   animation: fadeIn 0.6s ease forwards;
+ }
+
+ .buy {
+   background: var(--color-accent-3);
+   color: var(--color-bg);
+ }
+
+ .sell {
+   background: var(--color-negative);
+   color: #fff;
+ }
+
+ @keyframes fadeIn {
+   from {
+     opacity: 0;
+     transform: translateY(-10px);
+   }
+   to {
+     opacity: 1;
+     transform: translateY(0);
+   }
+ }
+

--- a/src/pages/Messages.jsx
+++ b/src/pages/Messages.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function Messages() {
-  return <div>Messages Page</div>;
-}
-
-export default Messages;


### PR DESCRIPTION
## Summary
- replace Messages with animated AI Signals page
- show mock RSI/EMA-based buy/sell alerts with confidence scores
- update navigation labels and tests to reference AI Signals

## Testing
- `npm install technicalindicators@3.1.0` *(fails: 403 Forbidden)*
- `npm test` *(fails: 4 failed | 7 passed | 8 skipped)*
- `npm run lint` *(fails: 127 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0471d3030832dad328fc302c9a849