### PR TITLE
Style news articles as cards

### DIFF
--- a/src/components/NewsDigest.jsx
+++ b/src/components/NewsDigest.jsx
@@ -1,30 +1,29 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./NewsDigest.module.scss";
+
+const mockArticles = [
+  {
+    url: "https://cointelegraph.com/",
+    title: "Bitcoin tops $70K for the first time 🚀",
+    description: "Market optimism pushes BTC above its all-time high.",
+  },
+  {
+    url: "https://decrypt.co/",
+    title: "Ethereum upgrade boosts transactions ⚡",
+    description: "ETH network speed improves following latest update.",
+  },
+  {
+    url: "https://cryptoslate.com/",
+    title: "Solana gains 12% amid NFT market surge 🎨",
+    description: "SOL rallies as NFT trading volume jumps.",
+  },
+];
 
 function NewsDigest() {
   const [articles, setArticles] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [atEnd, setAtEnd] = useState(false);
-
-  // Mock data (replace with API later if needed)
-  const mockArticles = [
-    {
-      url: "https://cointelegraph.com/",
-      title: "Bitcoin tops $70K for the first time 🚀",
-      description: "Market optimism pushes BTC above its all-time high.",
-    },
-    {
-      url: "https://decrypt.co/",
-      title: "Ethereum upgrade boosts transactions ⚡",
-      description: "ETH network speed improves following latest update.",
-    },
-    {
-      url: "https://cryptoslate.com/",
-      title: "Solana gains 12% amid NFT market surge 🎨",
-      description: "SOL rallies as NFT trading volume jumps.",
-    },
-  ];
 
   useEffect(() => {
     const today = new Date().toDateString();
@@ -67,12 +66,18 @@ function NewsDigest() {
       data-testid="news-digest"
     >
       {articles.map((article) => (
-        <article key={article.url} className={styles.article}>
+        <a
+          key={article.url}
+          href={article.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.card}
+        >
           <h3>{article.title}</h3>
           {article.description && <p>{article.description}</p>}
-        </article>
+        </a>
       ))}
-      {atEnd && <p className={styles.caughtUp}>You're all caught up!</p>}
+      {atEnd && <p className={styles.caughtUp}>You&apos;re all caught up!</p>}
     </div>
   );
 }

--- a/src/components/NewsDigest.module.scss
+++ b/src/components/NewsDigest.module.scss
@@ -1,14 +1,36 @@
 .container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: var(--space-md);
   max-height: 70vh;
   overflow-y: auto;
+  padding: var(--space-md);
 }
 
-.article {
-  margin-bottom: 1rem;
+.card {
+  display: block;
+  padding: var(--space-md);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.card h3 {
+  margin-bottom: var(--space-xs);
 }
 
 .caughtUp {
+  grid-column: 1 / -1;
   text-align: center;
-  margin-top: 1rem;
+  margin-top: var(--space-md);
   font-style: italic;
 }

--- a/src/components/NewsDigest.test.jsx
+++ b/src/components/NewsDigest.test.jsx
@@ -1,30 +1,21 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import NewsDigest from './NewsDigest';
 
-const mockArticles = [
-  { title: 'Article 1', description: 'Desc 1', url: '1' },
-  { title: 'Article 2', description: 'Desc 2', url: '2' },
-];
-
 describe('NewsDigest', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn(() =>
-      Promise.resolve({
-        json: () => Promise.resolve({ articles: mockArticles }),
-      })
-    ));
     localStorage.clear();
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
   });
 
   it("shows you're all caught up after scrolling to bottom", async () => {
     const { getByTestId } = render(<NewsDigest />);
-    await waitFor(() => expect(screen.getByText('Article 1')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText('Bitcoin tops $70K for the first time 🚀')
+      ).toBeInTheDocument()
+    );
 
     const container = getByTestId('news-digest');
     Object.defineProperty(container, 'scrollHeight', { value: 200, writable: true });


### PR DESCRIPTION
## Summary
- Display news articles as clickable cards with an updated grid layout for better readability
- Add responsive card styling for titles and descriptions
- Update tests to reflect new article content

## Testing
- `npx vitest run src/components/NewsDigest.test.jsx`
- `npm test` *(fails: Unable to find element, ResizeObserver is not defined)*
- `npm run lint` *(fails: 'React' must be in scope when using JSX, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a063e5a50c832d995a17df28b26dda