### PR TITLE
style: restyle news digest articles

### DIFF
--- a/src/components/NewsDigest.jsx
+++ b/src/components/NewsDigest.jsx
@@ -65,18 +65,31 @@ function NewsDigest() {
       onScroll={handleScroll}
       data-testid="news-digest"
     >
-      {articles.map((article) => (
-        <a
-          key={article.url}
-          href={article.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.card}
-        >
-          <h3>{article.title}</h3>
-          {article.description && <p>{article.description}</p>}
-        </a>
-      ))}
+      {articles.map((article) => {
+        const domain = new URL(article.url).hostname.replace("www.", "");
+        const placeholder =
+          "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64'><rect width='100%' height='100%' fill='%23ccc'/></svg>";
+        return (
+          <a
+            key={article.url}
+            href={article.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.card}
+          >
+            <div className={styles.content}>
+              <span className={styles.domain}>{domain}</span>
+              <h3>{article.title}</h3>
+              {article.description && <p>{article.description}</p>}
+            </div>
+            <img
+              src={article.image || placeholder}
+              alt=""
+              className={styles.thumbnail}
+            />
+          </a>
+        );
+      })}
       {atEnd && <p className={styles.caughtUp}>You&apos;re all caught up!</p>}
     </div>
   );

--- a/src/components/NewsDigest.module.scss
+++ b/src/components/NewsDigest.module.scss
@@ -1,6 +1,6 @@
 .container {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: var(--space-md);
   max-height: 70vh;
   overflow-y: auto;
@@ -8,8 +8,11 @@
 }
 
 .card {
-  display: block;
-  padding: var(--space-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
   border-radius: var(--radius-lg);
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);
@@ -24,12 +27,26 @@
   box-shadow: var(--shadow-md);
 }
 
-.card h3 {
+.content {
+  flex: 1;
+}
+
+.domain {
+  display: block;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
   margin-bottom: var(--space-xs);
 }
 
+.thumbnail {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
 .caughtUp {
-  grid-column: 1 / -1;
   text-align: center;
   margin-top: var(--space-md);
   font-style: italic;


### PR DESCRIPTION
## Summary
- Redesign news digest items into a list with source names and thumbnails
- Add vertical flex layout and styling for article cards

## Testing
- `npm test` *(fails: ReferenceError: ResizeObserver is not defined; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a069673a38832db3b9dc8ed7933b42